### PR TITLE
Allow custom duration for time attack mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <label for="mode">Modo</label>
             <select id="mode">
               <option value="survival">Supervivencia (3 vidas)</option>
-              <option value="time">Contrarreloj (60s)</option>
+              <option value="time">Contrarreloj (personalizable)</option>
             </select>
           </div>
 
@@ -42,6 +42,11 @@
               <option value="10" selected>10 s</option>
               <option value="12">12 s</option>
             </select>
+          </div>
+
+          <div class="row" id="timeAttackRow" hidden>
+            <label for="timeAttackTotal">Tiempo total (s)</label>
+            <input id="timeAttackTotal" type="number" min="10" max="300" step="10" value="60" />
           </div>
 
           <div class="row">

--- a/main.js
+++ b/main.js
@@ -14,6 +14,8 @@ const els = {
     mode: $("#mode"),
     difficulty: $("#difficulty"),
     timePerChar: $("#timePerChar"),
+    timeAttackTotal: $("#timeAttackTotal"),
+    timeAttackRow: $("#timeAttackRow"),
     permissive: $("#permissive"),
     soundEnabled: $("#soundEnabled"),
     theme: $("#theme"),
@@ -130,6 +132,7 @@ function saveSettings() {
     difficulty: state.difficulty,
     permissive: state.permissive,
     timePerChar: state.timePerChar,
+    timeAttackTotal: state.timeAttackTotal,
     soundEnabled: audio.enabled,
     theme: loadTheme(),
   };
@@ -143,12 +146,14 @@ function loadSettings() {
     if (cfg.difficulty) state.difficulty = cfg.difficulty;
     if (typeof cfg.permissive === "boolean") state.permissive = cfg.permissive;
     if (cfg.timePerChar) state.timePerChar = Number(cfg.timePerChar);
+    if (cfg.timeAttackTotal) state.timeAttackTotal = Number(cfg.timeAttackTotal);
     if (typeof cfg.soundEnabled === "boolean") audio.enabled = cfg.soundEnabled;
   } catch {}
 }
 
 function hsKey() {
-  return `${state.mode}-${state.difficulty}-${state.timePerChar}s`;
+  const base = `${state.mode}-${state.difficulty}-${state.timePerChar}s`;
+  return (state.mode === "time") ? `${base}-${state.timeAttackTotal}s` : base;
 }
 
 function saveHighscore(entry) {
@@ -427,6 +432,13 @@ async function init() {
   els.start.difficulty.value = state.difficulty;
   els.start.permissive.checked = state.permissive;
   els.start.timePerChar.value = String(state.timePerChar);
+  els.start.timeAttackTotal.value = String(state.timeAttackTotal);
+
+  const updateTimeRow = () => {
+    els.start.timeAttackRow.hidden = (els.start.mode.value !== "time");
+  };
+  updateTimeRow();
+  els.start.mode.addEventListener('change', updateTimeRow);
 
   // load data
   try {
@@ -450,6 +462,7 @@ async function init() {
     state.difficulty = els.start.difficulty.value;
     state.permissive = els.start.permissive.checked;
     state.timePerChar = Number(els.start.timePerChar.value);
+    state.timeAttackTotal = Number(els.start.timeAttackTotal.value);
     applyTheme(els.start.theme.value);
     audio.enabled = els.start.soundEnabled.checked;
     saveSettings();


### PR DESCRIPTION
## Summary
- add `Tiempo total` input to configure contrarreloj duration
- persist chosen duration and include it in high score grouping

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71a5c49c08322bf52f0f6685e29d6