### PR TITLE
Refresh UI and accessibility for Hiragana Rush

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,16 +13,19 @@
     <main class="container">
       <!-- Start Screen -->
       <section id="screen-start" class="screen">
-        <h1>Hiragana Rush</h1>
-        <p class="muted">Escribe la romanización correcta antes de que el tiempo llegue a cero.</p>
+        <header class="hero">
+          <h1>Hiragana Rush</h1>
+          <p class="tagline">aprende + compite</p>
+        </header>
 
         <div class="card settings">
           <div class="row">
             <label for="mode">Modo</label>
             <select id="mode">
               <option value="survival">Supervivencia (3 vidas)</option>
-              <option value="time">Contrarreloj (personalizable)</option>
+              <option value="time">Contrarreloj</option>
             </select>
+            <small class="hint">Elige entre vidas limitadas o tiempo total.</small>
           </div>
 
           <div class="row">
@@ -32,6 +35,7 @@
               <option value="medium">Medio (+ dakuten / handakuten)</option>
               <option value="hard">Difícil (+ yōon きゃ, しゃ, ちゃ...)</option>
             </select>
+            <small class="hint">Añade más kana para subir el reto.</small>
           </div>
 
           <div class="row">
@@ -42,39 +46,49 @@
               <option value="10" selected>10 s</option>
               <option value="12">12 s</option>
             </select>
+            <small class="hint">Tiempo límite para cada kana.</small>
           </div>
 
           <div class="row" id="timeAttackRow" hidden>
             <label for="timeAttackTotal">Tiempo total (s)</label>
             <input id="timeAttackTotal" type="number" min="10" max="300" step="10" value="60" />
+            <small class="hint">Disponible en Contrarreloj.</small>
           </div>
 
-          <div class="row">
+          <div class="row inline">
             <label class="switch">
               <input type="checkbox" id="permissive" checked />
               <span class="slider"></span>
             </label>
-            <span>Permisivo (acepta equivalencias: shi/si, chi/ti, tsu/tu...)</span>
+            <span>Permisivo (shi/si, chi/ti...)</span>
           </div>
-          <div class="row">
+          <div class="row inline">
             <label class="switch">
               <input type="checkbox" id="soundEnabled" checked />
               <span class="slider"></span>
             </label>
-            <span>Sonidos (acierto/fallo)</span>
+            <span>Sonidos</span>
+          </div>
+          <div class="row inline">
+            <label class="switch">
+              <input type="checkbox" id="showQueue" />
+              <span class="slider"></span>
+            </label>
+            <span>Mostrar cola</span>
           </div>
 
           <div class="row">
             <label for="theme">Tema</label>
             <select id="theme">
-              <option value="auto" selected>Auto (según sistema)</option>
+              <option value="auto" selected>Auto</option>
               <option value="dark">Oscuro</option>
               <option value="light">Claro</option>
             </select>
+            <small class="hint">Seguir sistema o forzar tema.</small>
           </div>
         </div>
 
-        <button id="btn-start" class="primary">Comenzar</button>
+        <button id="btn-start" class="primary start-fixed">Comenzar</button>
       </section>
 
       <!-- Game Screen -->
@@ -90,15 +104,25 @@
           <div id="timerFill"></div>
         </div>
 
+        <div id="nextQueue" class="queue" hidden></div>
+
         <div class="play">
           <div id="kana" class="kana">あ</div>
-          <input id="answer" class="answer" type="text" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" inputmode="latin" placeholder="romanización..." />
-          <div id="feedback" class="feedback muted"></div>
+          <p id="inputHint" class="sr-only">Escribe la romanización y presiona Enter para validar.</p>
+          <input id="answer" class="answer" type="text" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" inputmode="latin" placeholder="romanización..." aria-describedby="inputHint" />
+          <div id="toast" class="toast" role="status" aria-live="polite"></div>
         </div>
 
         <footer class="controls">
           <button id="btn-quit" class="ghost">Salir</button>
         </footer>
+
+        <div id="pauseOverlay" class="overlay hidden" role="dialog" aria-modal="true">
+          <div class="modal">
+            <p>Pausa</p>
+            <small>Presiona Esc para continuar</small>
+          </div>
+        </div>
       </section>
 
       <!-- Result Screen -->
@@ -123,13 +147,27 @@
       </section>
     </main>
 
+    <div id="onboard" class="overlay hidden" role="dialog" aria-modal="true">
+      <div class="modal">
+        <div id="onboardStep1" class="onboard-step">
+          <p>Escribe la romanización usando letras latinas. Ej: し → shi</p>
+          <button id="onboardNext" class="primary">Siguiente</button>
+        </div>
+        <div id="onboardStep2" class="onboard-step hidden">
+          <p>Cada carácter tiene un límite de tiempo. En Supervivencia tienes 3 vidas.</p>
+          <label class="row inline"><input type="checkbox" id="onboardSkip" /> No volver a mostrar</label>
+          <button id="onboardDone" class="primary">Listo</button>
+        </div>
+      </div>
+    </div>
+
     <script src="./main.js" defer></script>
-      <script>
+    <script>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {
           navigator.serviceWorker.register("./service-worker.js").catch(console.error);
         });
       }
     </script>
-</body>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,4 @@
-
-/* THEME: light & dark via [data-theme] on <html> */
+/* Theme colors */
 html[data-theme="dark"] {
   --bg: #0b0f14;
   --card: #121822;
@@ -8,6 +7,7 @@ html[data-theme="dark"] {
   --accent: #5dd6ff;
   --good: #40d37a;
   --bad: #ff6b6b;
+  --warn: #f5c344;
 }
 
 html[data-theme="light"] {
@@ -18,6 +18,7 @@ html[data-theme="light"] {
   --accent: #1976d2;
   --good: #2e7d32;
   --bad: #c62828;
+  --warn: #c67c00;
 }
 
 @media (prefers-color-scheme: light) {
@@ -29,6 +30,7 @@ html[data-theme="light"] {
     --accent: #1976d2;
     --good: #2e7d32;
     --bad: #c62828;
+    --warn: #c67c00;
   }
 }
 @media (prefers-color-scheme: dark) {
@@ -40,14 +42,26 @@ html[data-theme="light"] {
     --accent: #5dd6ff;
     --good: #40d37a;
     --bad: #ff6b6b;
+    --warn: #f5c344;
   }
 }
-/* Minimal, clean, responsive */
+
+:root {
+  --font-base: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  --radius-sm: 8px;
+  --radius: 12px;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --transition: 150ms;
+  --shadow: 0 10px 30px rgba(0,0,0,.25);
+}
+
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
   margin: 0;
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-base);
   color: var(--text);
   background: radial-gradient(1200px 800px at 20% -10%, #152233 0%, var(--bg) 60%);
 }
@@ -56,143 +70,141 @@ body {
   margin: 0 auto;
   padding: clamp(16px, 5vw, 24px);
 }
-h1, h2, h3 { margin: 0 0 12px; letter-spacing: .3px; }
-p { color: var(--muted); }
-
-.screen { display: block; }
 .hidden { display: none !important; }
+.sr-only { position: absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
 
-.card {
-  background: linear-gradient(180deg, #121826, #0f1621);
-  border: 1px solid rgba(255,255,255,.06);
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 10px 30px rgba(0,0,0,.25);
-}
-.row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin: 10px 0;
-  flex-wrap: wrap;
-}
-label { width: 180px; color: var(--muted); }
-.row select,
-.row input[type="text"] {
-  flex: 1;
-  min-width: 0;
-}
-select, input[type="text"] {
-  background: #0d1420; color: var(--text);
-  border: 1px solid rgba(255,255,255,.09);
-  border-radius: 10px; padding: 10px 12px;
-}
-.primary, .ghost {
-  border-radius: 12px;
-  padding: 10px 16px;
-  border: 1px solid rgba(255,255,255,.09);
-  background: #162238; color: var(--text); cursor: pointer;
-  min-height: 44px;
-  touch-action: manipulation;
-}
-button,
-input,
-select {
+:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
+button, input, select {
   font-family: inherit;
   font-size: 1rem;
   min-height: 44px;
   touch-action: manipulation;
+  transition: background var(--transition), color var(--transition);
+}
+
+.primary, .ghost {
+  border-radius: var(--radius);
+  padding: 10px 16px;
+  border: 1px solid rgba(255,255,255,.09);
+  background: #162238;
+  color: var(--text);
+  cursor: pointer;
 }
 .primary { background: linear-gradient(180deg, #1b2d49, #162238); border-color: rgba(93,214,255,.35); }
-.primary:hover { outline: 2px solid rgba(93,214,255,.35); }
-.ghost:hover { outline: 1px solid rgba(255,255,255,.2); }
-.muted { color: var(--muted); }
+.primary:hover { outline:2px solid rgba(93,214,255,.35); }
+.ghost:hover { outline:1px solid rgba(255,255,255,.2); }
 
-.hud {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  margin-bottom: 10px;
+.hero { text-align: center; margin-bottom: var(--space-md); }
+.tagline { color: var(--muted); }
+
+#screen-start { display:flex; flex-direction:column; min-height:100vh; }
+.settings {
+  background: linear-gradient(180deg, #121826, #0f1621);
+  border: 1px solid rgba(255,255,255,.06);
+  border-radius: var(--radius);
+  padding: 16px;
+  box-shadow: var(--shadow);
 }
+.row { display:flex; flex-direction:column; margin: var(--space-sm) 0; }
+.row.inline { flex-direction:row; align-items:center; }
+.row.inline label { margin-right:12px; width:auto; }
+.row.inline span { flex:1; }
+.row label { color: var(--muted); }
+.row .hint { margin-top:4px; color: var(--muted); font-size:.85rem; }
+select, input[type="number"], input[type="text"] {
+  background: #0d1420; color: var(--text);
+  border: 1px solid rgba(255,255,255,.09);
+  border-radius: var(--radius-sm); padding: 10px 12px;
+}
+#btn-start.start-fixed { position:sticky; bottom:0; margin-top:auto; }
+
+.hud { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:10px; }
 .stat {
   background: #0e1623;
   border: 1px solid rgba(255,255,255,.06);
-  border-radius: 12px;
+  border-radius: var(--radius);
   padding: 8px 10px;
-  display: flex; align-items: center; justify-content: space-between;
+  display:flex; align-items:center; justify-content:space-between;
 }
 .stat .label { color: var(--muted); }
 
 .timer {
-  width: 100%; height: 10px;
-  background: #0c1320; border: 1px solid rgba(255,255,255,.05);
-  border-radius: 999px; overflow: hidden;
-  margin-bottom: 18px;
+  width:100%; height:10px;
+  background: #0c1320; border:1px solid rgba(255,255,255,.05);
+  border-radius:999px; overflow:hidden;
+  margin-bottom:18px;
 }
 #timerFill {
-  height: 100%; width: 100%;
+  height:100%; width:100%;
   background: linear-gradient(90deg, var(--good), var(--accent));
-  transform-origin: left center; transform: scaleX(1);
+  transform-origin:left center; transform:scaleX(1);
   transition: transform .12s linear;
 }
+#timerFill.warn { animation: pulse 1s ease-in-out infinite; }
+@keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:.5;} }
+
+.queue { display:flex; justify-content:center; gap:8px; margin-bottom:16px; }
+.queue span { font-size:32px; opacity:.6; }
 
 .play {
-  display: grid; place-items: center; gap: 12px;
-  padding: 24px; border-radius: 16px;
+  position:relative;
+  display:grid; place-items:center; gap:12px;
+  padding:24px; border-radius:var(--radius);
   background: linear-gradient(180deg, rgba(93,214,255,.04), rgba(93,214,255,.02));
   border: 1px solid rgba(255,255,255,.06);
 }
-.kana {
-  font-size: clamp(88px, 12vw, 168px);
-  line-height: 1;
-  text-shadow: 0 8px 28px rgba(93,214,255,.18);
+.kana { font-size:clamp(120px,12vw,160px); line-height:1; text-shadow:0 8px 28px rgba(93,214,255,.18); }
+.answer { width:min(520px,90%); text-align:center; font-size:22px; }
+.toast {
+  position:absolute; top:100%; left:50%; transform:translate(-50%,8px);
+  padding:4px 8px; border-radius:var(--radius-sm);
+  background: var(--card); box-shadow: var(--shadow);
+  opacity:0; pointer-events:none;
+  transition: opacity var(--transition), transform var(--transition);
 }
-.answer {
-  width: min(520px, 90%);
-  text-align: center;
-  font-size: 22px;
+.toast.show { opacity:1; transform:translate(-50%,0); }
+.toast.good { color: var(--good); }
+.toast.bad { color: var(--bad); }
+
+.results { display:grid; grid-template-columns:repeat(2,1fr); gap:8px; }
+.results .label { color: var(--muted); margin-right:8px; }
+.hiscore { padding-left:20px; }
+
+.controls { display:flex; justify-content:flex-end; margin-top:14px; }
+
+.overlay {
+  position:fixed; inset:0;
+  background:rgba(0,0,0,.6);
+  display:flex; align-items:center; justify-content:center;
+  padding:16px;
 }
-.feedback { min-height: 24px; }
-.feedback.good { color: var(--good); }
-.feedback.bad { color: var(--bad); }
-
-.notes { margin-top: 18px; }
-
-.results {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+.modal {
+  background: var(--card);
+  padding:24px;
+  border-radius:var(--radius);
+  max-width:320px;
+  text-align:center;
+  box-shadow: var(--shadow);
 }
-.results .label { color: var(--muted); margin-right: 8px; }
+.onboard-step { display:flex; flex-direction:column; gap:16px; }
 
-.hiscore { padding-left: 20px; }
-
-.controls { display: flex; justify-content: flex-end; margin-top: 14px; }
-
-/* Toggle switch */
-.switch { position: relative; display: inline-block; width: 44px; height: 24px; }
-.switch input { opacity: 0; width: 0; height: 0; }
+.switch { position:relative; display:inline-block; width:44px; height:24px; }
+.switch input { opacity:0; width:0; height:0; }
 .slider {
-  position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0;
-  background: #0f1a2a; border: 1px solid rgba(255,255,255,.12);
-  transition: .2s; border-radius: 999px;
+  position:absolute; cursor:pointer; top:0; left:0; right:0; bottom:0;
+  background:#0f1a2a; border:1px solid rgba(255,255,255,.12);
+  transition:.2s; border-radius:999px;
 }
 .slider:before {
-  position: absolute; content: ""; height: 18px; width: 18px; left: 2px; bottom: 2px;
-  background: #fff; border-radius: 50%; transition: .2s;
+  position:absolute; content:""; height:18px; width:18px; left:2px; bottom:2px;
+  background:#fff; border-radius:50%; transition:.2s;
 }
-input:checked + .slider { background: #183a54; }
-input:checked + .slider:before { transform: translateX(20px); }
+input:checked + .slider { background:#183a54; }
+input:checked + .slider:before { transform:translateX(20px); }
 
-@media (max-width: 1024px) {
-  .hud { grid-template-columns: repeat(3, 1fr); }
-}
-
-@media (max-width: 640px) {
-  .hud { grid-template-columns: repeat(2, 1fr); }
-  .results { grid-template-columns: 1fr; }
-  .row { flex-direction: column; align-items: stretch; }
-  label { width: 100%; }
-  .row select,
-  .row input[type="text"] { width: 100%; }
+@media (max-width:1024px) { .hud { grid-template-columns:repeat(3,1fr); } }
+@media (max-width:640px) {
+  .hud { grid-template-columns:repeat(2,1fr); }
+  .results { grid-template-columns:1fr; }
 }


### PR DESCRIPTION
## Summary
- revamp start screen and add optional kana queue
- add toast feedback, onboarding, and pause overlay
- improve keyboard navigation and accessibility tokens

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b71c608a6083228552b6936598fc1b