### PR TITLE
Refactor layout with sidebar and basic router

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,163 +6,40 @@
     <title>Hiragana Rush — Typing Trainer</title>
     <link rel="stylesheet" href="./styles.css" />
     <link rel="manifest" href="./manifest.webmanifest" />
-    <meta name="theme-color" content="#0b0f14" />
+    <meta name="theme-color" content="#0b0d12" />
     <meta name="description" content="Juego rápido para practicar Hiragana. Escribe la romanización antes de que el tiempo se acabe." />
   </head>
   <body>
-    <main class="container">
-      <!-- Start Screen -->
-      <section id="screen-start" class="screen">
-        <header class="hero">
-          <h1>Hiragana Rush</h1>
-          <p class="tagline">aprende + compite</p>
+    <div class="app">
+      <aside id="sidebar" role="navigation" aria-label="Modo de juego">
+        <div class="logo">Hiragana Rush</div>
+        <nav class="menu">
+          <button class="menu-item" data-mode="classic" aria-current="page">Clásico</button>
+          <button class="menu-item" data-mode="timeattack">Time Attack</button>
+          <button class="menu-item" data-mode="practice">Práctica</button>
+          <button class="menu-item" data-mode="custom">Personalizado</button>
+        </nav>
+        <div class="sidebar-footer">
+          <label class="switch">
+            <input id="themeToggle" type="checkbox" />
+            <span>🌙 Tema oscuro</span>
+          </label>
+        </div>
+      </aside>
+
+      <div class="shell">
+        <header class="topbar">
+          <button id="btnSidebar" aria-controls="sidebar" aria-expanded="true">☰</button>
+          <h1 id="viewTitle">Clásico</h1>
         </header>
 
-        <div class="card settings">
-          <div class="row">
-            <label for="mode">Modo</label>
-            <select id="mode">
-              <option value="survival">Supervivencia (3 vidas)</option>
-              <option value="time">Contrarreloj</option>
-            </select>
-            <small class="hint">Elige entre vidas limitadas o tiempo total.</small>
-          </div>
-
-          <div class="row">
-            <label for="difficulty">Dificultad</label>
-            <select id="difficulty">
-              <option value="easy">Fácil (gojūon básico)</option>
-              <option value="medium">Medio (+ dakuten / handakuten)</option>
-              <option value="hard">Difícil (+ yōon きゃ, しゃ, ちゃ...)</option>
-            </select>
-            <small class="hint">Añade más kana para subir el reto.</small>
-          </div>
-
-          <div class="row">
-            <label for="timePerChar">Tiempo por carácter</label>
-            <select id="timePerChar">
-              <option value="6">6 s</option>
-              <option value="8">8 s</option>
-              <option value="10" selected>10 s</option>
-              <option value="12">12 s</option>
-            </select>
-            <small class="hint">Tiempo límite para cada kana.</small>
-          </div>
-
-          <div class="row" id="timeAttackRow" hidden>
-            <label for="timeAttackTotal">Tiempo total (s)</label>
-            <input id="timeAttackTotal" type="number" min="10" max="300" step="10" value="60" />
-            <small class="hint">Disponible en Contrarreloj.</small>
-          </div>
-
-          <div class="row inline">
-            <label class="switch">
-              <input type="checkbox" id="permissive" checked />
-              <span class="slider"></span>
-            </label>
-            <span>Permisivo (shi/si, chi/ti...)</span>
-          </div>
-          <div class="row inline">
-            <label class="switch">
-              <input type="checkbox" id="soundEnabled" checked />
-              <span class="slider"></span>
-            </label>
-            <span>Sonidos</span>
-          </div>
-          <div class="row inline">
-            <label class="switch">
-              <input type="checkbox" id="showQueue" />
-              <span class="slider"></span>
-            </label>
-            <span>Mostrar cola</span>
-          </div>
-
-          <div class="row">
-            <label for="theme">Tema</label>
-            <select id="theme">
-              <option value="auto" selected>Auto</option>
-              <option value="dark">Oscuro</option>
-              <option value="light">Claro</option>
-            </select>
-            <small class="hint">Seguir sistema o forzar tema.</small>
-          </div>
-        </div>
-
-        <button id="btn-start" class="primary start-fixed">Comenzar</button>
-      </section>
-
-      <!-- Game Screen -->
-      <section id="screen-game" class="screen hidden">
-        <header class="hud">
-          <div class="stat"><span class="label">Puntos</span><span id="score">0</span></div>
-          <div class="stat"><span class="label">Combo</span><span id="combo">0</span></div>
-          <div class="stat"><span class="label" id="livesLabel">Vidas</span><span id="lives">3</span></div>
-          <div class="stat" id="timeBox" hidden><span class="label">Tiempo</span><span id="timeLeft">60</span>s</div>
-        </header>
-
-        <div class="timer">
-          <div id="timerFill"></div>
-        </div>
-
-        <div id="nextQueue" class="queue" hidden></div>
-
-        <div class="play">
-          <div id="kana" class="kana">あ</div>
-          <p id="inputHint" class="sr-only">Escribe la romanización y presiona Enter para validar.</p>
-          <input id="answer" class="answer" type="text" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" inputmode="latin" placeholder="romanización..." aria-describedby="inputHint" />
-          <div id="toast" class="toast" role="status" aria-live="polite"></div>
-        </div>
-
-        <footer class="controls">
-          <button id="btn-quit" class="ghost">Salir</button>
-        </footer>
-
-        <div id="pauseOverlay" class="overlay hidden" role="dialog" aria-modal="true">
-          <div class="modal">
-            <p>Pausa</p>
-            <small>Presiona Esc para continuar</small>
-          </div>
-        </div>
-      </section>
-
-      <!-- Result Screen -->
-      <section id="screen-result" class="screen hidden">
-        <h2>Resultado</h2>
-        <div class="card results">
-          <div><span class="label">Puntos</span><span id="rScore">0</span></div>
-          <div><span class="label">Aciertos</span><span id="rHits">0</span></div>
-          <div><span class="label">Fallos</span><span id="rMiss">0</span></div>
-          <div><span class="label">Precisión</span><span id="rAcc">0%</span></div>
-          <div><span class="label">Combo máximo</span><span id="rCombo">0</span></div>
-          <div><span class="label">Tiempo jugado</span><span id="rTime">0s</span></div>
-        </div>
-
-        <h3>Top 5 (local)</h3>
-        <ol id="highscores" class="hiscore"></ol>
-
-        <div class="actions">
-          <button id="btn-retry" class="primary">Reintentar</button>
-          <button id="btn-home" class="ghost">Inicio</button>
-        </div>
-      </section>
-    </main>
-
-    <div id="onboard" class="overlay hidden" role="dialog" aria-modal="true">
-      <div class="modal">
-        <div id="onboardStep1" class="onboard-step">
-          <p>Escribe la romanización usando letras latinas. Ej: し → shi</p>
-          <button id="onboardNext" class="primary">Siguiente</button>
-        </div>
-        <div id="onboardStep2" class="onboard-step hidden">
-          <p>Cada carácter tiene un límite de tiempo. En Supervivencia tienes 3 vidas.</p>
-          <label class="row inline"><input type="checkbox" id="onboardSkip" /> No volver a mostrar</label>
-          <button id="onboardDone" class="primary">Listo</button>
-        </div>
+        <main id="mainView" tabindex="-1"></main>
       </div>
     </div>
 
     <script src="./data/hiragana.js" defer></script>
     <script src="./main.js" defer></script>
+    <script src="./ui.js" defer></script>
     <script>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", () => {

--- a/main.js
+++ b/main.js
@@ -4,59 +4,61 @@
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => document.querySelectorAll(sel);
 
-const els = {
-  screens: {
-    start: $("#screen-start"),
-    game: $("#screen-game"),
-    result: $("#screen-result"),
-  },
-  start: {
-    mode: $("#mode"),
-    difficulty: $("#difficulty"),
-    timePerChar: $("#timePerChar"),
-    timeAttackTotal: $("#timeAttackTotal"),
-    timeAttackRow: $("#timeAttackRow"),
-    permissive: $("#permissive"),
-    soundEnabled: $("#soundEnabled"),
-    showQueue: $("#showQueue"),
-    theme: $("#theme"),
-    startBtn: $("#btn-start"),
-  },
-  game: {
-    score: $("#score"),
-    combo: $("#combo"),
-    lives: $("#lives"),
-    livesLabel: $("#livesLabel"),
-    timeBox: $("#timeBox"),
-    timeLeft: $("#timeLeft"),
-    timerFill: $("#timerFill"),
-    kana: $("#kana"),
-    answer: $("#answer"),
-    queue: $("#nextQueue"),
-    toast: $("#toast"),
-    quitBtn: $("#btn-quit"),
-    pauseOverlay: $("#pauseOverlay"),
-  },
-  result: {
-    score: $("#rScore"),
-    hits: $("#rHits"),
-    miss: $("#rMiss"),
-    acc: $("#rAcc"),
-    combo: $("#rCombo"),
-    time: $("#rTime"),
-    highscores: $("#highscores"),
-    retry: $("#btn-retry"),
-    home: $("#btn-home"),
-  },
-  onboard: {
-    root: $("#onboard"),
-    step1: $("#onboardStep1"),
-    step2: $("#onboardStep2"),
-    next: $("#onboardNext"),
-    done: $("#onboardDone"),
-    skip: $("#onboardSkip"),
-  }
-};
+let els;
+function bindEls() {
+  els = {
+    screens: {
+      start: $("#screen-start"),
+      game: $("#screen-game"),
+      result: $("#screen-result"),
+    },
+    start: {
+      mode: $("#mode"),
+      difficulty: $("#difficulty"),
+      timePerChar: $("#timePerChar"),
+      timeAttackTotal: $("#timeAttackTotal"),
+      timeAttackRow: $("#timeAttackRow"),
+      permissive: $("#permissive"),
+      soundEnabled: $("#soundEnabled"),
+      showQueue: $("#showQueue"),
+      startBtn: $("#btn-start"),
+    },
+    game: {
+      score: $("#score"),
+      combo: $("#combo"),
+      lives: $("#lives"),
+      livesLabel: $("#livesLabel"),
+      timeBox: $("#timeBox"),
+      timeLeft: $("#timeLeft"),
+      timerFill: $("#timerFill"),
+      kana: $("#kana"),
+      answer: $("#answer"),
+      queue: $("#nextQueue"),
+      toast: $("#toast"),
+      quitBtn: $("#btn-quit"),
+      pauseOverlay: $("#pauseOverlay"),
+    },
+    result: {
+      score: $("#rScore"),
+      hits: $("#rHits"),
+      miss: $("#rMiss"),
+      acc: $("#rAcc"),
+      combo: $("#rCombo"),
+      time: $("#rTime"),
+      highscores: $("#highscores"),
+      retry: $("#btn-retry"),
+      home: $("#btn-home"),
+    },
+    onboard: {
+      root: $("#onboard"),
+      step1: $("#onboardStep1"),
+      step2: $("#onboardStep2"),
+      next: $("#onboardNext"),
+      done: $("#onboardDone"),
+      skip: $("#onboardSkip"),
+    }
+  };
+}
 
 const STORAGE_KEYS = {
   settings: "htg_settings_v3",
@@ -143,17 +145,6 @@ const audio = {
   timeout() { this.beep(110, 220, 'sawtooth', 0.05); },
 };
 
-// -------------- Theme handling --------------
-function applyTheme(mode) {
-  const html = document.documentElement;
-  if (!['auto','dark','light'].includes(mode)) mode = 'auto';
-  html.setAttribute('data-theme', mode);
-  try { localStorage.setItem(STORAGE_KEYS.theme, mode); } catch {}
-}
-function loadTheme() {
-  try { return localStorage.getItem(STORAGE_KEYS.theme) || 'auto'; } catch { return 'auto'; }
-}
-
 function saveSettings() {
   const payload = {
     mode: state.mode,
@@ -162,7 +153,6 @@ function saveSettings() {
     timePerChar: state.timePerChar,
     timeAttackTotal: state.timeAttackTotal,
     soundEnabled: audio.enabled,
-    theme: loadTheme(),
     showQueue: state.showQueue,
   };
   try { localStorage.setItem(STORAGE_KEYS.settings, JSON.stringify(payload)); } catch {}
@@ -483,11 +473,10 @@ function showOnboard() {
 
 // -------------- Wiring --------------
 async function init() {
+  bindEls();
   loadSettings();
 
   // apply settings to UI
-  applyTheme(loadTheme());
-  els.start.theme.value = loadTheme();
   els.start.soundEnabled.checked = audio.enabled;
   els.start.showQueue.checked = state.showQueue;
 
@@ -496,7 +485,6 @@ async function init() {
   document.addEventListener('click', unlockAudio, { once: true });
 
   // Change handlers
-  els.start.theme.addEventListener('change', (e) => applyTheme(e.target.value));
   els.start.soundEnabled.addEventListener('change', (e) => { audio.enabled = e.target.checked; saveSettings(); });
   els.start.showQueue.addEventListener('change', (e) => { state.showQueue = e.target.checked; saveSettings(); });
 
@@ -551,7 +539,6 @@ async function init() {
     state.timePerChar = Number(els.start.timePerChar.value);
     state.timeAttackTotal = Number(els.start.timeAttackTotal.value);
     state.showQueue = els.start.showQueue.checked;
-    applyTheme(els.start.theme.value);
     audio.enabled = els.start.soundEnabled.checked;
     saveSettings();
     buildPool();
@@ -611,4 +598,9 @@ async function init() {
   });
 }
 
-window.addEventListener("DOMContentLoaded", init);
+
+function setGameMode(mode){
+  state.mode = mode;
+}
+
+window.game = { init, setGameMode };

--- a/styles.css
+++ b/styles.css
@@ -1,62 +1,29 @@
-/* Theme colors */
-html[data-theme="dark"] {
-  --bg: #0b0f14;
-  --card: #121822;
-  --text: #e7edf4;
-  --muted: #9fb2c6;
-  --accent: #5dd6ff;
-  --good: #40d37a;
-  --bad: #ff6b6b;
-  --warn: #f5c344;
-}
-
-html[data-theme="light"] {
-  --bg: #f5f7fb;
-  --card: #ffffff;
-  --text: #1c2a3a;
-  --muted: #5a6b7d;
-  --accent: #1976d2;
-  --good: #2e7d32;
-  --bad: #c62828;
-  --warn: #c67c00;
-}
-
-@media (prefers-color-scheme: light) {
-  html[data-theme="auto"] {
-    --bg: #f5f7fb;
-    --card: #ffffff;
-    --text: #1c2a3a;
-    --muted: #5a6b7d;
-    --accent: #1976d2;
-    --good: #2e7d32;
-    --bad: #c62828;
-    --warn: #c67c00;
-  }
-}
-@media (prefers-color-scheme: dark) {
-  html[data-theme="auto"] {
-    --bg: #0b0f14;
-    --card: #121822;
-    --text: #e7edf4;
-    --muted: #9fb2c6;
-    --accent: #5dd6ff;
-    --good: #40d37a;
-    --bad: #ff6b6b;
-    --warn: #f5c344;
-  }
-}
-
 :root {
+  --bg: #0b0d12;
+  --panel: #12161f;
+  --card: var(--panel);
+  --text: #e6ebf2;
+  --muted: #94a3b8;
+  --accent: #6aa6ff;
+  --danger: #ff6a7a;
+  --radius: 12px;
   --font-base: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
   --radius-sm: 8px;
-  --radius: 12px;
   --space-xs: 4px;
   --space-sm: 8px;
   --space-md: 16px;
   --transition: 150ms;
   --shadow: 0 10px 30px rgba(0,0,0,.25);
 }
-
+[data-theme="light"] {
+  --bg:#f7f8fb;
+  --panel:#ffffff;
+  --card: var(--panel);
+  --text:#0b1220;
+  --muted:#5b677a;
+  --accent:#3b82f6;
+  --danger:#ef4444;
+}
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {
@@ -65,16 +32,22 @@ body {
   color: var(--text);
   background: radial-gradient(1200px 800px at 20% -10%, #152233 0%, var(--bg) 60%);
 }
-.container {
-  max-width: 880px;
-  margin: 0 auto;
-  padding: clamp(16px, 5vw, 24px);
+.app { display:grid; grid-template-columns: 280px 1fr; height:100dvh; background:var(--bg); color:var(--text); }
+aside#sidebar { background:var(--panel); border-right:1px solid #1e2430; padding:16px; }
+.shell { display:flex; flex-direction:column; min-width:0; }
+.topbar { display:flex; gap:12px; align-items:center; padding:12px 16px; border-bottom:1px solid #1e2430; background:var(--panel); }
+#mainView { padding:16px; overflow:auto; }
+.menu .menu-item { width:100%; text-align:left; padding:10px 12px; border-radius:8px; border:0; background:transparent; color:var(--text); }
+.menu .menu-item[aria-current="page"] { background: #1a2230; outline:2px solid var(--accent); }
+#btnSidebar { display:none; background:none; border:0; font-size:24px; color:var(--text); }
+@media (max-width: 1024px) {
+  .app { grid-template-columns: 0 1fr; }
+  .app.sidebar-open { grid-template-columns: 280px 1fr; }
+  #btnSidebar { display:inline-flex; }
 }
 .hidden { display: none !important; }
 .sr-only { position: absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
-
 :focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
-
 button, input, select {
   font-family: inherit;
   font-size: 1rem;
@@ -82,7 +55,6 @@ button, input, select {
   touch-action: manipulation;
   transition: background var(--transition), color var(--transition);
 }
-
 .primary, .ghost {
   border-radius: var(--radius);
   padding: 10px 16px;
@@ -94,10 +66,8 @@ button, input, select {
 .primary { background: linear-gradient(180deg, #1b2d49, #162238); border-color: rgba(93,214,255,.35); }
 .primary:hover { outline:2px solid rgba(93,214,255,.35); }
 .ghost:hover { outline:1px solid rgba(255,255,255,.2); }
-
 .hero { text-align: center; margin-bottom: var(--space-md); }
 .tagline { color: var(--muted); }
-
 #screen-start { display:flex; flex-direction:column; min-height:100vh; }
 .settings {
   background: linear-gradient(180deg, #121826, #0f1621);
@@ -118,7 +88,6 @@ select, input[type="number"], input[type="text"] {
   border-radius: var(--radius-sm); padding: 10px 12px;
 }
 #btn-start.start-fixed { position:sticky; bottom:0; margin-top:auto; }
-
 .hud { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:10px; }
 .stat {
   background: #0e1623;
@@ -128,7 +97,6 @@ select, input[type="number"], input[type="text"] {
   display:flex; align-items:center; justify-content:space-between;
 }
 .stat .label { color: var(--muted); }
-
 .timer {
   width:100%; height:10px;
   background: #0c1320; border:1px solid rgba(255,255,255,.05);
@@ -137,16 +105,14 @@ select, input[type="number"], input[type="text"] {
 }
 #timerFill {
   height:100%; width:100%;
-  background: linear-gradient(90deg, var(--good), var(--accent));
+  background: linear-gradient(90deg, var(--accent), var(--danger));
   transform-origin:left center; transform:scaleX(1);
   transition: transform .12s linear;
 }
 #timerFill.warn { animation: pulse 1s ease-in-out infinite; }
 @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:.5;} }
-
 .queue { display:flex; justify-content:center; gap:8px; margin-bottom:16px; }
 .queue span { font-size:32px; opacity:.6; }
-
 .play {
   position:relative;
   display:grid; place-items:center; gap:12px;
@@ -164,15 +130,12 @@ select, input[type="number"], input[type="text"] {
   transition: opacity var(--transition), transform var(--transition);
 }
 .toast.show { opacity:1; transform:translate(-50%,0); }
-.toast.good { color: var(--good); }
-.toast.bad { color: var(--bad); }
-
+.toast.good { color: var(--accent); }
+.toast.bad { color: var(--danger); }
 .results { display:grid; grid-template-columns:repeat(2,1fr); gap:8px; }
 .results .label { color: var(--muted); margin-right:8px; }
 .hiscore { padding-left:20px; }
-
 .controls { display:flex; justify-content:flex-end; margin-top:14px; }
-
 .overlay {
   position:fixed; inset:0;
   background:rgba(0,0,0,.6);
@@ -182,13 +145,12 @@ select, input[type="number"], input[type="text"] {
 .modal {
   background: var(--card);
   padding:24px;
-  border-radius:var(--radius);
+  border-radius: var(--radius);
   max-width:320px;
   text-align:center;
   box-shadow: var(--shadow);
 }
 .onboard-step { display:flex; flex-direction:column; gap:16px; }
-
 .switch { position:relative; display:inline-block; width:44px; height:24px; }
 .switch input { opacity:0; width:0; height:0; }
 .slider {
@@ -202,7 +164,6 @@ select, input[type="number"], input[type="text"] {
 }
 input:checked + .slider { background:#183a54; }
 input:checked + .slider:before { transform:translateX(20px); }
-
 @media (max-width:1024px) { .hud { grid-template-columns:repeat(3,1fr); } }
 @media (max-width:640px) {
   .hud { grid-template-columns:repeat(2,1fr); }

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,263 @@
+// Minimal UI router and theme handling
+(function(){
+  const app = document.querySelector('.app');
+  const mainView = document.getElementById('mainView');
+  const viewTitle = document.getElementById('viewTitle');
+  const btnSidebar = document.getElementById('btnSidebar');
+  const themeToggle = document.getElementById('themeToggle');
+  const modeTitles = {
+    classic: 'Clásico',
+    timeattack: 'Time Attack',
+    practice: 'Práctica',
+    custom: 'Personalizado'
+  };
+  const templates = {
+    classic: `
+      <div class="container">
+        <!-- Start Screen -->
+        <section id="screen-start" class="screen">
+          <header class="hero">
+            <h1>Hiragana Rush</h1>
+            <p class="tagline">aprende + compite</p>
+          </header>
+
+          <div class="card settings">
+            <div class="row">
+              <label for="mode">Modo</label>
+              <select id="mode">
+                <option value="survival">Supervivencia (3 vidas)</option>
+                <option value="time">Contrarreloj</option>
+              </select>
+              <small class="hint">Elige entre vidas limitadas o tiempo total.</small>
+            </div>
+
+            <div class="row">
+              <label for="difficulty">Dificultad</label>
+              <select id="difficulty">
+                <option value="easy">Fácil (gojūon básico)</option>
+                <option value="medium">Medio (+ dakuten / handakuten)</option>
+                <option value="hard">Difícil (+ yōon きゃ, しゃ, ちゃ...)</option>
+              </select>
+              <small class="hint">Añade más kana para subir el reto.</small>
+            </div>
+
+            <div class="row">
+              <label for="timePerChar">Tiempo por carácter</label>
+              <select id="timePerChar">
+                <option value="6">6 s</option>
+                <option value="8">8 s</option>
+                <option value="10" selected>10 s</option>
+                <option value="12">12 s</option>
+              </select>
+              <small class="hint">Tiempo límite para cada kana.</small>
+            </div>
+
+            <div class="row" id="timeAttackRow" hidden>
+              <label for="timeAttackTotal">Tiempo total (s)</label>
+              <input id="timeAttackTotal" type="number" min="10" max="300" step="10" value="60" />
+              <small class="hint">Disponible en Contrarreloj.</small>
+            </div>
+
+            <div class="row inline">
+              <label class="switch">
+                <input type="checkbox" id="permissive" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Permisivo (shi/si, chi/ti...)</span>
+            </div>
+            <div class="row inline">
+              <label class="switch">
+                <input type="checkbox" id="soundEnabled" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Sonidos</span>
+            </div>
+            <div class="row inline">
+              <label class="switch">
+                <input type="checkbox" id="showQueue" />
+                <span class="slider"></span>
+              </label>
+              <span>Mostrar cola</span>
+            </div>
+          </div>
+
+          <button id="btn-start" class="primary start-fixed">Comenzar</button>
+        </section>
+
+        <!-- Game Screen -->
+        <section id="screen-game" class="screen hidden">
+          <header class="hud">
+            <div class="stat"><span class="label">Puntos</span><span id="score">0</span></div>
+            <div class="stat"><span class="label">Combo</span><span id="combo">0</span></div>
+            <div class="stat"><span class="label" id="livesLabel">Vidas</span><span id="lives">3</span></div>
+            <div class="stat" id="timeBox" hidden><span class="label">Tiempo</span><span id="timeLeft">60</span>s</div>
+          </header>
+
+          <div class="timer">
+            <div id="timerFill"></div>
+          </div>
+
+          <div id="nextQueue" class="queue" hidden></div>
+
+          <div class="play">
+            <div id="kana" class="kana">あ</div>
+            <p id="inputHint" class="sr-only">Escribe la romanización y presiona Enter para validar.</p>
+            <input id="answer" class="answer" type="text" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" inputmode="latin" placeholder="romanización..." aria-describedby="inputHint" />
+            <div id="toast" class="toast" role="status" aria-live="polite"></div>
+          </div>
+
+          <footer class="controls">
+            <button id="btn-quit" class="ghost">Salir</button>
+          </footer>
+
+          <div id="pauseOverlay" class="overlay hidden" role="dialog" aria-modal="true">
+            <div class="modal">
+              <p>Pausa</p>
+              <small>Presiona Esc para continuar</small>
+            </div>
+          </div>
+        </section>
+
+        <!-- Result Screen -->
+        <section id="screen-result" class="screen hidden">
+          <h2>Resultado</h2>
+          <div class="card results">
+            <div><span class="label">Puntos</span><span id="rScore">0</span></div>
+            <div><span class="label">Aciertos</span><span id="rHits">0</span></div>
+            <div><span class="label">Fallos</span><span id="rMiss">0</span></div>
+            <div><span class="label">Precisión</span><span id="rAcc">0%</span></div>
+            <div><span class="label">Combo máximo</span><span id="rCombo">0</span></div>
+            <div><span class="label">Tiempo jugado</span><span id="rTime">0s</span></div>
+          </div>
+
+          <h3>Top 5 (local)</h3>
+          <ol id="highscores" class="hiscore"></ol>
+
+          <div class="actions">
+            <button id="btn-retry" class="primary">Reintentar</button>
+            <button id="btn-home" class="ghost">Inicio</button>
+          </div>
+        </section>
+      </div>
+      <div id="onboard" class="overlay hidden" role="dialog" aria-modal="true">
+        <div class="modal">
+          <div id="onboardStep1" class="onboard-step">
+            <p>Escribe la romanización usando letras latinas. Ej: し → shi</p>
+            <button id="onboardNext" class="primary">Siguiente</button>
+          </div>
+          <div id="onboardStep2" class="onboard-step hidden">
+            <p>Cada carácter tiene un límite de tiempo. En Supervivencia tienes 3 vidas.</p>
+            <label class="row inline"><input type="checkbox" id="onboardSkip" /> No volver a mostrar</label>
+            <button id="onboardDone" class="primary">Listo</button>
+          </div>
+        </div>
+      </div>
+    `,
+    timeattack: `<div class="placeholder"><p>Modo Time Attack próximamente.</p></div>`,
+    practice: `<div class="placeholder"><p>Modo Práctica próximamente.</p></div>`,
+    custom: `<form id="customForm" class="card settings">
+      <fieldset>
+        <legend>Conjuntos</legend>
+        <label><input type="checkbox" value="a" /> a,i,u,e,o</label>
+        <label><input type="checkbox" value="k" /> k-</label>
+        <label><input type="checkbox" value="s" /> s-</label>
+        <label><input type="checkbox" value="t" /> t-</label>
+        <label><input type="checkbox" value="n" /> n-</label>
+        <label><input type="checkbox" value="h" /> h-</label>
+        <label><input type="checkbox" value="m" /> m-</label>
+        <label><input type="checkbox" value="y" /> y-</label>
+        <label><input type="checkbox" value="r" /> r-</label>
+        <label><input type="checkbox" value="w" /> w-</label>
+        <label><input type="checkbox" value="nn" /> ん</label>
+      </fieldset>
+      <div class="row">
+        <label for="customTime">Tiempo por carácter</label>
+        <input id="customTime" type="range" min="2" max="12" value="10" />
+      </div>
+      <div class="row inline">
+        <label class="switch">
+          <input type="checkbox" id="customPermissive" />
+          <span class="slider"></span>
+        </label>
+        <span>Permisivo</span>
+      </div>
+      <button id="saveCustom" class="primary">Guardar configuración</button>
+    </form>`
+  };
+
+  const views = {};
+
+  function applyTheme(pref){
+    if(pref === 'light'){
+      document.documentElement.setAttribute('data-theme','light');
+      themeToggle.checked = false;
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+      themeToggle.checked = true;
+    }
+    try { localStorage.setItem('theme', pref); } catch {}
+  }
+
+  function setAria(mode){
+    document.querySelectorAll('.menu-item').forEach(btn => {
+      if(btn.dataset.mode === mode) btn.setAttribute('aria-current','page');
+      else btn.removeAttribute('aria-current');
+    });
+  }
+
+  function renderView(mode){
+    if(!views[mode]){
+      const wrap = document.createElement('div');
+      wrap.dataset.view = mode;
+      wrap.innerHTML = templates[mode] || '';
+      wrap.hidden = true;
+      views[mode] = wrap;
+      mainView.appendChild(wrap);
+      if(mode === 'classic' && window.game && typeof window.game.init === 'function'){
+        window.game.init();
+      }
+    }
+    Object.values(views).forEach(v => v.hidden = true);
+    views[mode].hidden = false;
+    viewTitle.textContent = modeTitles[mode] || '';
+    mainView.focus();
+    setAria(mode);
+    if(window.game && typeof window.game.setGameMode === 'function'){
+      window.game.setGameMode(mode);
+    }
+  }
+
+  function getModeFromHash(){
+    const m = location.hash.match(/#\/mode\/(classic|timeattack|practice|custom)/);
+    return m ? m[1] : null;
+  }
+
+  function handleRoute(){
+    const mode = getModeFromHash() || localStorage.getItem('mode') || 'classic';
+    renderView(mode);
+    try { localStorage.setItem('mode', mode); } catch {}
+  }
+
+  function bindSidebar(){
+    document.querySelector('.menu').addEventListener('click', e => {
+      const btn = e.target.closest('.menu-item');
+      if(btn){
+        location.hash = `#/mode/${btn.dataset.mode}`;
+      }
+    });
+  }
+
+  function toggleSidebar(){
+    const open = app.classList.toggle('sidebar-open');
+    btnSidebar.setAttribute('aria-expanded', open);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bindSidebar();
+    btnSidebar.addEventListener('click', toggleSidebar);
+    themeToggle.addEventListener('change', () => applyTheme(themeToggle.checked ? 'dark' : 'light'));
+    applyTheme(localStorage.getItem('theme') || 'dark');
+    window.addEventListener('hashchange', handleRoute);
+    handleRoute();
+  });
+})();


### PR DESCRIPTION
## Summary
- introduce sidebar layout with theme switcher
- add hash-based router and classic view template
- expose game API for mode switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b89fe70832280d1ccef6e8c510e