### PR TITLE
fix sidebar overflow on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,13 +33,14 @@ body {
   background: radial-gradient(1200px 800px at 20% -10%, #152233 0%, var(--bg) 60%);
 }
 .app { display:grid; grid-template-columns: 280px 1fr; height:100dvh; background:var(--bg); color:var(--text); }
-aside#sidebar { background:var(--panel); border-right:1px solid #1e2430; padding:16px; }
+aside#sidebar { background:var(--panel); border-right:1px solid #1e2430; padding:16px; overflow:hidden; }
 .shell { display:flex; flex-direction:column; min-width:0; }
 .topbar { display:flex; gap:12px; align-items:center; padding:12px 16px; border-bottom:1px solid #1e2430; background:var(--panel); }
 #mainView { padding:16px; overflow:auto; }
 .menu .menu-item { width:100%; text-align:left; padding:10px 12px; border-radius:8px; border:0; background:transparent; color:var(--text); }
 .menu .menu-item[aria-current="page"] { background: #1a2230; outline:2px solid var(--accent); }
 #btnSidebar { display:none; background:none; border:0; font-size:24px; color:var(--text); }
+.app.sidebar-open aside#sidebar { overflow:auto; }
 @media (max-width: 1024px) {
   .app { grid-template-columns: 0 1fr; }
   .app.sidebar-open { grid-template-columns: 280px 1fr; }


### PR DESCRIPTION
## Summary
- hide sidebar content when collapsed on narrow viewports

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b84e9802948322b68cc298e268747f